### PR TITLE
Specify required plone.api version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,0 +1,14 @@
+Changelog
+=========
+
+
+1.0.1 (unreleased)
+------------------
+
+- Specify required plone.api version. [lknoepfel]
+
+
+1.0.0 (2016-07-20)
+--------------------
+
+- Initial implementation and first release. [lknoepfel]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import os
 
 version = '1.0.1.dev0'
 maintainer = '4teamwork'
@@ -20,7 +21,8 @@ setup(
     name='ftw.protectinactive',
     version=version,
     description='ftw.protectinactive',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst').read() + '\n' + open(
+        os.path.join('docs', 'HISTORY.txt')).read(),
 
     # Get more strings from
     # http://www.python.org/pypi?%3Aaction=list_classifiers
@@ -47,7 +49,7 @@ setup(
 
     install_requires=[
         'Plone',
-        'plone.api',
+        'plone.api>=1.3',
         'plone.app.dexterity',
         'plone.dexterity',
         'setuptools',


### PR DESCRIPTION
Installed `ftw.protectinactive` on a customer policy and broke the whole site because i had an old `plone.api` version. :hushed:

Also initialized HISTORY.txt.
