### PR TITLE
Improve traversal hook.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Improve traversal hook in order not block authorized users from viewing
+  content they should be allowed to view. [mbaechtold]
+
 - Fix failing tests because of recent changes in "ftw.testbrowser". [mbaechtold]
 
 - Test against Plone 4.2. [mbaechtold]

--- a/ftw/protectinactive/traversalhook.py
+++ b/ftw/protectinactive/traversalhook.py
@@ -20,8 +20,9 @@ def protect_incative_hook(event):
 
     context = findContext(event.request)
 
-    if api.user.has_permission('Modify portal content', obj=context):
-        return
+    for permission in ['Modify portal content', 'Request review', 'Review portal content']:
+        if api.user.has_permission(permission, obj=context):
+            return
 
     publication_date, expiration_date = getPublicationDates(context)
 


### PR DESCRIPTION
This is needed in order not to block authorized users from viewing content they should be allowed to view.
  